### PR TITLE
fix: load and validate required env vars at startup (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,13 @@
-# Copy this file to .env and customize values as needed for your local
-# development or CI environment.
+# Copy this file to .env and replace placeholder values.
 
-# Soroban network selection (profile name). Valid values: testnet, mainnet, sandbox
-SOROBAN_NETWORK=testnet
+# Target Stellar network (for example: testnet, mainnet).
+STELLAR_NETWORK=testnet
 
-# Override the RPC endpoint and network passphrase if necessary
+# Platform account secret seed used for signing platform transactions.
+STELLAR_PLATFORM_SECRET=SBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Horizon REST API endpoint for the selected network.
+HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Soroban RPC endpoint for the selected network.
 SOROBAN_RPC_URL=https://rpc.testnet.soroban.stellar.org
-SOROBAN_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
-
-# Example keypair file path; tools may read this
-# SOROBAN_KEY_FILE=./keys/contract-key.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 name = "contract-fox"
 version = "0.1.0"
 dependencies = [
+ "dotenvy",
  "ed25519-dalek",
  "reqwest",
  "serde",
@@ -431,6 +432,12 @@ dependencies = [
  "soroban-sdk",
  "stellar-strkey",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ stellar-strkey  = "0.0.8"
 ed25519-dalek   = "2"
 tracing     = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+dotenvy = "0.15"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,43 @@
+use std::env;
+
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub stellar_network: String,
+    pub stellar_platform_secret: String,
+    pub horizon_url: String,
+    pub soroban_rpc_url: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("missing required environment variable: {0}")]
+    MissingEnvVar(&'static str),
+
+    #[error("environment variable {name} cannot be empty")]
+    EmptyEnvVar { name: &'static str },
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        dotenvy::dotenv().ok();
+
+        Ok(Self {
+            stellar_network: read_required_env("STELLAR_NETWORK")?,
+            stellar_platform_secret: read_required_env("STELLAR_PLATFORM_SECRET")?,
+            horizon_url: read_required_env("HORIZON_URL")?,
+            soroban_rpc_url: read_required_env("SOROBAN_RPC_URL")?,
+        })
+    }
+}
+
+fn read_required_env(name: &'static str) -> Result<String, ConfigError> {
+    let value = env::var(name).map_err(|_| ConfigError::MissingEnvVar(name))?;
+
+    if value.trim().is_empty() {
+        return Err(ConfigError::EmptyEnvVar { name });
+    }
+
+    Ok(value)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod errors;
 
 pub mod friendbot;
@@ -5,4 +6,9 @@ pub mod horizon;
 mod setup;
 pub mod utils;
 
-fn main() {}
+fn main() {
+    if let Err(err) = config::Config::from_env() {
+        eprintln!("Startup configuration error: {err}");
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
Closes #24

## Changes
- Added `dotenvy` crate to load environment variables from `.env` at startup.
- Added a new config module at `src/config.rs` with:
  - `Config` struct
  - `Config::from_env()` loader
  - Required variable checks for:
    - `STELLAR_NETWORK`
    - `STELLAR_PLATFORM_SECRET`
    - `HORIZON_URL`
    - `SOROBAN_RPC_URL`
  - Descriptive errors for missing and empty required variables.
- Updated startup flow in `src/main.rs` to:
  - load and validate config at process start
  - print `Startup configuration error: ...` and exit with code `1` if invalid
- Updated `.env.example` with all required keys and clear descriptions.
- Updated `Cargo.lock` for new dependency resolution.

## Testing
- Ran `cargo test` in repository root.
- Result: all tests passing (`41 passed, 0 failed`).

## Acceptance Criteria Check
- Service now fails at startup with a clear message when any required env var is missing.
- Required env vars are loaded and validated at startup.
- `.env.example` includes all required keys with descriptions.
