### PR TITLE
feat(contracts): create Soroban campaign registry contract

### DIFF
--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -1,24 +1,14 @@
 #![no_std]
 
-use soroban_sdk::{Address, Env, Map, Symbol, Vec, contract, contractimpl, contracttype, symbol_short};
+use contracts_shared::{Campaign, CampaignStatus};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, Env, Map, Symbol, Vec,
+};
 
-// Storage keys
 const CAMPAIGN_MAP: Symbol = symbol_short!("CMP_MAP");
 const CAMPAIGN_COUNT: Symbol = symbol_short!("CMP_CNT");
-const CAMPAIGN_RAISED: Symbol = symbol_short!("CMP_RAS");
 const PAUSED: Symbol = symbol_short!("PAUSED");
 const ADMIN: Symbol = symbol_short!("ADMIN");
-
-// Campaign status constants
-pub const CAMPAIGN_STATUS_ACTIVE: u32 = 0;
-pub const CAMPAIGN_STATUS_COMPLETED: u32 = 1;
-pub const CAMPAIGN_STATUS_CANCELLED: u32 = 2;
-pub const CAMPAIGN_STATUS_EXPIRED: u32 = 3;
-
-// Campaign data tuple: (id, owner, goal, deadline, status, created_at)
-pub type Campaign = (u64, Address, i128, u64, u32, u64);
-
-// --- Structured Events for Off-Chain Indexing ---
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -33,8 +23,8 @@ pub struct CampaignRegisteredEvent {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CampaignStatusChangedEvent {
     pub campaign_id: u64,
-    pub old_status: u32,
-    pub new_status: u32,
+    pub old_status: CampaignStatus,
+    pub new_status: CampaignStatus,
 }
 
 #[contracttype]
@@ -61,7 +51,6 @@ pub struct CampaignContract;
 
 #[contractimpl]
 impl CampaignContract {
-    /// Initialize the contract and set the admin address
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&ADMIN) {
             panic!("Contract is already initialized");
@@ -69,7 +58,6 @@ impl CampaignContract {
         env.storage().instance().set(&ADMIN, &admin);
     }
 
-    /// Pause the contract; only the admin can call this
     pub fn pause(env: Env, admin: Address) {
         admin.require_auth();
         let stored_admin: Address = env
@@ -87,7 +75,6 @@ impl CampaignContract {
         );
     }
 
-    /// Unpause the contract; only the admin can call this
     pub fn unpause(env: Env, admin: Address) {
         admin.require_auth();
         let stored_admin: Address = env
@@ -105,7 +92,6 @@ impl CampaignContract {
         );
     }
 
-    /// Register a new campaign
     pub fn register_campaign(env: Env, owner: Address, goal: i128, deadline: u64) -> u64 {
         require_not_paused(&env);
         owner.require_auth();
@@ -113,14 +99,14 @@ impl CampaignContract {
         let mut count: u64 = env.storage().instance().get(&CAMPAIGN_COUNT).unwrap_or(0);
         count += 1;
 
-        let campaign: Campaign = (
-            count,
-            owner.clone(),
+        let campaign = Campaign {
+            id: count,
+            owner: owner.clone(),
             goal,
+            raised: 0,
+            status: CampaignStatus::Active,
             deadline,
-            CAMPAIGN_STATUS_ACTIVE,
-            env.ledger().timestamp(),
-        );
+        };
 
         let mut campaigns: Map<u64, Campaign> = env
             .storage()
@@ -144,7 +130,6 @@ impl CampaignContract {
         count
     }
 
-    /// Get campaign details by ID
     pub fn get_campaign(env: Env, campaign_id: u64) -> Campaign {
         let campaigns: Map<u64, Campaign> = env
             .storage()
@@ -157,8 +142,7 @@ impl CampaignContract {
             .unwrap_or_else(|| panic!("Campaign not found"))
     }
 
-    /// Update campaign status
-    pub fn update_campaign_status(env: Env, campaign_id: u64, status: u32) {
+    pub fn update_campaign_status(env: Env, campaign_id: u64, status: CampaignStatus) {
         require_not_paused(&env);
 
         let mut campaigns: Map<u64, Campaign> = env
@@ -167,16 +151,15 @@ impl CampaignContract {
             .get(&CAMPAIGN_MAP)
             .unwrap_or_else(|| panic!("No campaigns found"));
 
-        let campaign = campaigns
+        let mut campaign = campaigns
             .get(campaign_id)
             .unwrap_or_else(|| panic!("Campaign not found"));
 
-        let (id, owner, goal, deadline, old_status, created_at) = campaign;
+        campaign.owner.require_auth();
 
-        owner.require_auth();
-
-        let updated_campaign: Campaign = (id, owner, goal, deadline, status, created_at);
-        campaigns.set(campaign_id, updated_campaign);
+        let old_status = campaign.status.clone();
+        campaign.status = status.clone();
+        campaigns.set(campaign_id, campaign);
         env.storage().instance().set(&CAMPAIGN_MAP, &campaigns);
 
         env.events().publish(
@@ -189,12 +172,10 @@ impl CampaignContract {
         );
     }
 
-    /// Get total number of campaigns
     pub fn get_campaign_count(env: Env) -> u64 {
         env.storage().instance().get(&CAMPAIGN_COUNT).unwrap_or(0)
     }
 
-    /// Get all campaigns (utility function for testing)
     pub fn get_all_campaigns(env: Env) -> Vec<Campaign> {
         let campaigns: Map<u64, Campaign> = env
             .storage()
@@ -214,7 +195,6 @@ impl CampaignContract {
         result
     }
 
-    /// Update raised amount for a campaign (can be called by other contracts)
     pub fn update_raised_amount(env: Env, campaign_id: u64, amount: i128) {
         require_not_paused(&env);
 
@@ -222,35 +202,215 @@ impl CampaignContract {
             panic!("Amount must be positive");
         }
 
-        let campaigns: Map<u64, Campaign> = env
+        let mut campaigns: Map<u64, Campaign> = env
             .storage()
             .instance()
             .get(&CAMPAIGN_MAP)
             .unwrap_or_else(|| panic!("No campaigns found"));
 
-        if !campaigns.contains_key(campaign_id) {
-            panic!("Campaign not found");
-        }
+        let mut campaign = campaigns
+            .get(campaign_id)
+            .unwrap_or_else(|| panic!("Campaign not found"));
 
-        let mut raised_amounts: Map<u64, i128> = env
-            .storage()
-            .instance()
-            .get(&CAMPAIGN_RAISED)
-            .unwrap_or(Map::new(&env));
-
-        let current_raised: i128 = raised_amounts.get(campaign_id).unwrap_or(0);
-        raised_amounts.set(campaign_id, current_raised + amount);
-        env.storage().instance().set(&CAMPAIGN_RAISED, &raised_amounts);
+        campaign.raised += amount;
+        campaigns.set(campaign_id, campaign);
+        env.storage().instance().set(&CAMPAIGN_MAP, &campaigns);
     }
 
-    /// Get raised amount for a campaign
     pub fn get_raised_amount(env: Env, campaign_id: u64) -> i128 {
-        let raised_amounts: Map<u64, i128> = env
+        let campaigns: Map<u64, Campaign> = env
             .storage()
             .instance()
-            .get(&CAMPAIGN_RAISED)
+            .get(&CAMPAIGN_MAP)
             .unwrap_or(Map::new(&env));
 
-        raised_amounts.get(campaign_id).unwrap_or(0)
+        campaigns
+            .get(campaign_id)
+            .map(|c| c.raised)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_register_and_get_campaign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let owner = Address::generate(&env);
+        let goal = 1000i128;
+        let deadline = 1700000000u64;
+
+        let id = client.register_campaign(&owner, &goal, &deadline);
+        assert_eq!(id, 1);
+
+        let campaign = client.get_campaign(&id);
+        assert_eq!(campaign.id, 1);
+        assert_eq!(campaign.owner, owner);
+        assert_eq!(campaign.goal, goal);
+        assert_eq!(campaign.raised, 0);
+        assert_eq!(campaign.status, CampaignStatus::Active);
+        assert_eq!(campaign.deadline, deadline);
+
+        assert_eq!(client.get_campaign_count(), 1);
+    }
+
+    #[test]
+    fn test_update_campaign_status() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let owner = Address::generate(&env);
+        let id = client.register_campaign(&owner, &1000i128, &1700000000u64);
+
+        client.update_campaign_status(&id, &CampaignStatus::Completed);
+
+        let campaign = client.get_campaign(&id);
+        assert_eq!(campaign.status, CampaignStatus::Completed);
+    }
+
+    #[test]
+    fn test_multiple_campaigns() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let owner1 = Address::generate(&env);
+        let owner2 = Address::generate(&env);
+
+        let id1 = client.register_campaign(&owner1, &500i128, &1700000000u64);
+        let id2 = client.register_campaign(&owner2, &1000i128, &1800000000u64);
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(client.get_campaign_count(), 2);
+
+        let all = client.get_all_campaigns();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_update_raised_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let owner = Address::generate(&env);
+        let id = client.register_campaign(&owner, &1000i128, &1700000000u64);
+
+        client.update_raised_amount(&id, &250i128);
+        assert_eq!(client.get_raised_amount(&id), 250);
+
+        client.update_raised_amount(&id, &150i128);
+        assert_eq!(client.get_raised_amount(&id), 400);
+
+        let campaign = client.get_campaign(&id);
+        assert_eq!(campaign.raised, 400);
+    }
+
+    #[test]
+    #[should_panic(expected = "Contract is already initialized")]
+    fn test_prevent_double_initialization() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        client.initialize(&admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Campaign not found")]
+    fn test_get_nonexistent_campaign() {
+        let env = Env::default();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        client.get_campaign(&999u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "Amount must be positive")]
+    fn test_update_raised_zero_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let owner = Address::generate(&env);
+        let id = client.register_campaign(&owner, &1000i128, &1700000000u64);
+
+        client.update_raised_amount(&id, &0i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Contract is paused")]
+    fn test_register_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        client.pause(&admin);
+
+        let owner = Address::generate(&env);
+        client.register_campaign(&owner, &1000i128, &1700000000u64);
+    }
+
+    #[test]
+    fn test_pause_and_unpause() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        client.pause(&admin);
+        client.unpause(&admin);
+
+        let owner = Address::generate(&env);
+        let id = client.register_campaign(&owner, &1000i128, &1700000000u64);
+        assert_eq!(id, 1);
     }
 }


### PR DESCRIPTION
## Summary
- Refactored campaign contract to use proper `Campaign` struct and `CampaignStatus` enum from shared types, replacing raw tuples and `u32` status constants
- `update_campaign_status` now accepts `CampaignStatus` enum for type-safe status transitions
- Integrated `raised` amount tracking directly into the `Campaign` struct, eliminating the separate `CAMPAIGN_RAISED` storage map
- Added comprehensive test suite covering registration, status updates, raised amounts, pause/unpause, and edge cases

## Changes
- **`contracts/campaign/src/lib.rs`**: Complete implementation using shared types (`Campaign`, `CampaignStatus`), with all required functions (`register_campaign`, `get_campaign`, `update_campaign_status`, `get_campaign_count`), event emissions (`CampaignRegistered`, `CampaignStatusUpdated`), and tests

## Test plan
- [x] Contract compiles successfully (`cargo build -p campaign-contract`)
- [x] Campaign can be registered and retrieved from contract storage
- [x] Campaign status can be updated using `CampaignStatus` enum
- [x] Multiple campaigns can be registered and counted
- [x] Raised amount tracking works via `update_raised_amount`
- [x] Pause/unpause mechanism prevents operations when paused
- [x] Edge cases handled (double init, nonexistent campaign, zero amount)

Closes #31