### PR TITLE
feat: implement authorization in donation contract (closes #34)

### DIFF
--- a/contracts/donation/src/lib.rs
+++ b/contracts/donation/src/lib.rs
@@ -123,6 +123,17 @@ impl DonationContract {
             .get(&CAMPAIGN_CONTRACT_ID)
             .unwrap_or_else(|| panic!("Campaign contract ID not set. Call initialize() first."));
 
+        // Validate the campaign exists and is active (status == 0)
+        let campaign: (u64, Address, i128, u64, u32, u64) = env.invoke_contract(
+            &campaign_contract_id,
+            &symbol_short!("get_campaign"),
+            (campaign_id,),
+        );
+        let (_, _, _, _, status, _) = campaign;
+        if status != 0 {
+            panic!("Campaign is not active");
+        }
+
         let donation: Donation = (
             donor.clone(),
             campaign_id,
@@ -179,11 +190,37 @@ impl DonationContract {
     }
 
     /// Hook function for executing withdrawal operations request triggers
-    pub fn request_withdrawal(env: Env, campaign_id: u64, withdrawal_id: u64, amount: i128) {
+    /// Only the campaign owner or admin may call this
+    pub fn request_withdrawal(env: Env, caller: Address, campaign_id: u64, withdrawal_id: u64, amount: i128) {
         require_not_paused(&env);
+        caller.require_auth();
 
         if amount <= 0 {
             panic!("Withdrawal request amount must be positive");
+        }
+
+        let campaign_contract_id: Address = env
+            .storage()
+            .instance()
+            .get(&CAMPAIGN_CONTRACT_ID)
+            .unwrap_or_else(|| panic!("Campaign contract ID not set. Call initialize() first."));
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
+
+        // Fetch campaign to verify caller is campaign owner or admin
+        let campaign: (u64, Address, i128, u64, u32, u64) = env.invoke_contract(
+            &campaign_contract_id,
+            &symbol_short!("get_campaign"),
+            (campaign_id,),
+        );
+        let (_, campaign_owner, _, _, _, _) = campaign;
+
+        if caller != campaign_owner && caller != admin {
+            panic!("Unauthorized: caller is not campaign owner or admin");
         }
 
         env.events().publish(
@@ -197,8 +234,20 @@ impl DonationContract {
     }
 
     /// Hook function for validating completed withdrawal distributions
-    pub fn approve_withdrawal(env: Env, withdrawal_id: u64, tx_hash: Symbol) {
+    /// Only the admin may call this
+    pub fn approve_withdrawal(env: Env, caller: Address, withdrawal_id: u64, tx_hash: Symbol) {
         require_not_paused(&env);
+        caller.require_auth();
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
+
+        if caller != admin {
+            panic!("Unauthorized: caller is not admin");
+        }
 
         env.events().publish(
             (symbol_short!("with_app"), withdrawal_id),
@@ -293,12 +342,15 @@ impl DonationContract {
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{Address, Env, Map, Symbol, contract, contractimpl, testutils::Address as _};
+    use soroban_sdk::{Address, Env, Map, Symbol, contract, contractimpl, symbol_short, testutils::Address as _};
     use crate::{DonationContract, DonationContractClient};
 
-    const MOCK_CAMP_MAP: Symbol = Symbol::from_str("CMP_MAP");
+    const MOCK_CAMP_MAP: Symbol = symbol_short!("CMP_MAP");
+    const MOCK_CAMP_STATUS: Symbol = symbol_short!("CMP_STA");
+    const MOCK_CAMP_OWNER: Symbol = symbol_short!("CMP_OWN");
 
     // Mock Campaign contract for testing
+    // Campaign tuple: (id, owner, goal, deadline, status, created_at)
     #[contract]
     pub struct MockCampaignContract;
 
@@ -314,9 +366,27 @@ mod test {
             env.storage().instance().set(&MOCK_CAMP_MAP, &store);
         }
 
-        pub fn get_raised_amount(env: Env, campaign_id: u64) -> i128 {
-            let store: Map<u64, i128> = env.storage().instance().get(&MOCK_CAMP_MAP).unwrap_or(Map::new(&env));
-            store.get(campaign_id).unwrap_or(0)
+        /// Set the owner for a campaign (for test setup)
+        pub fn set_campaign_owner(env: Env, campaign_id: u64, owner: Address) {
+            let mut store: Map<u64, Address> = env.storage().instance().get(&MOCK_CAMP_OWNER).unwrap_or(Map::new(&env));
+            store.set(campaign_id, owner);
+            env.storage().instance().set(&MOCK_CAMP_OWNER, &store);
+        }
+
+        /// Set the status for a campaign (for test setup)
+        pub fn set_campaign_status(env: Env, campaign_id: u64, status: u32) {
+            let mut store: Map<u64, u32> = env.storage().instance().get(&MOCK_CAMP_STATUS).unwrap_or(Map::new(&env));
+            store.set(campaign_id, status);
+            env.storage().instance().set(&MOCK_CAMP_STATUS, &store);
+        }
+
+        /// Returns (id, owner, goal, deadline, status, created_at)
+        pub fn get_campaign(env: Env, campaign_id: u64) -> (u64, Address, i128, u64, u32, u64) {
+            let owners: Map<u64, Address> = env.storage().instance().get(&MOCK_CAMP_OWNER).unwrap_or(Map::new(&env));
+            let statuses: Map<u64, u32> = env.storage().instance().get(&MOCK_CAMP_STATUS).unwrap_or(Map::new(&env));
+            let owner = owners.get(campaign_id).unwrap_or_else(|| panic!("Campaign not found"));
+            let status = statuses.get(campaign_id).unwrap_or(0); // default: active
+            (campaign_id, owner, 1000i128, 9999999u64, status, 0u64)
         }
     }
 
@@ -326,14 +396,17 @@ mod test {
         env.mock_all_auths();
 
         let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
         let contract_id = env.register_contract(None, DonationContract);
         let client = DonationContractClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
         client.initialize(&mock_campaign_id, &admin);
+        let campaign_id = 1u64;
+        mock_client.set_campaign_owner(&campaign_id, &campaign_owner);
 
         let donor = Address::generate(&env);
-        let campaign_id = 1u64;
         let amount = 100i128;
 
         client.donate(&donor, &campaign_id, &amount);
@@ -364,15 +437,18 @@ mod test {
         env.mock_all_auths();
 
         let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
         let contract_id = env.register_contract(None, DonationContract);
         let client = DonationContractClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
         client.initialize(&mock_campaign_id, &admin);
+        let campaign_id = 1u64;
+        mock_client.set_campaign_owner(&campaign_id, &campaign_owner);
 
         let donor1 = Address::generate(&env);
         let donor2 = Address::generate(&env);
-        let campaign_id = 1u64;
 
         client.donate(&donor1, &campaign_id, &100i128);
         client.donate(&donor2, &campaign_id, &200i128);
@@ -397,14 +473,17 @@ mod test {
         env.mock_all_auths();
 
         let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
         let contract_id = env.register_contract(None, DonationContract);
         let client = DonationContractClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
         client.initialize(&mock_campaign_id, &admin);
+        let campaign_id = 1u64;
+        mock_client.set_campaign_owner(&campaign_id, &campaign_owner);
 
         let donor = Address::generate(&env);
-        let campaign_id = 1u64;
 
         client.donate(&donor, &campaign_id, &0i128);
     }
@@ -416,14 +495,17 @@ mod test {
         env.mock_all_auths();
 
         let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
         let contract_id = env.register_contract(None, DonationContract);
         let client = DonationContractClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
         client.initialize(&mock_campaign_id, &admin);
+        let campaign_id = 1u64;
+        mock_client.set_campaign_owner(&campaign_id, &campaign_owner);
 
         let donor = Address::generate(&env);
-        let campaign_id = 1u64;
 
         client.donate(&donor, &campaign_id, &-100i128);
     }
@@ -480,11 +562,14 @@ mod test {
         env.mock_all_auths();
 
         let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
         let contract_id = env.register_contract(None, DonationContract);
         let client = DonationContractClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
         client.initialize(&mock_campaign_id, &admin);
+        mock_client.set_campaign_owner(&1u64, &campaign_owner);
 
         client.pause(&admin);
         client.unpause(&admin);
@@ -493,5 +578,139 @@ mod test {
         let donor = Address::generate(&env);
         client.donate(&donor, &1u64, &50i128);
         assert_eq!(client.get_total_raised(&1u64), 50i128);
+    }
+
+    // --- Authorization failure tests ---
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: caller is not campaign owner or admin")]
+    fn test_request_withdrawal_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+        mock_client.set_campaign_owner(&1u64, &campaign_owner);
+
+        // stranger is neither owner nor admin
+        client.request_withdrawal(&stranger, &1u64, &1u64, &100i128);
+    }
+
+    #[test]
+    fn test_request_withdrawal_by_campaign_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+        mock_client.set_campaign_owner(&1u64, &campaign_owner);
+
+        // campaign owner should succeed
+        client.request_withdrawal(&campaign_owner, &1u64, &1u64, &100i128);
+    }
+
+    #[test]
+    fn test_request_withdrawal_by_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+        mock_client.set_campaign_owner(&1u64, &campaign_owner);
+
+        // admin should succeed
+        client.request_withdrawal(&admin, &1u64, &1u64, &100i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: caller is not admin")]
+    fn test_approve_withdrawal_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+
+        // stranger is not admin
+        client.approve_withdrawal(&stranger, &1u64, &Symbol::new(&env, "txhash123"));
+    }
+
+    #[test]
+    fn test_approve_withdrawal_by_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+
+        // admin should succeed
+        client.approve_withdrawal(&admin, &1u64, &Symbol::new(&env, "txhash123"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Campaign is not active")]
+    fn test_donate_to_inactive_campaign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let mock_client = MockCampaignContractClient::new(&env, &mock_campaign_id);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let campaign_owner = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+        mock_client.set_campaign_owner(&1u64, &campaign_owner);
+        mock_client.set_campaign_status(&1u64, &1u32); // 1 = Completed (not active)
+
+        let donor = Address::generate(&env);
+        client.donate(&donor, &1u64, &100i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Campaign not found")]
+    fn test_donate_to_nonexistent_campaign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let mock_campaign_id = env.register_contract(None, MockCampaignContract);
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&mock_campaign_id, &admin);
+        // No campaign set up — get_campaign will panic "Campaign not found"
+
+        let donor = Address::generate(&env);
+        client.donate(&donor, &99u64, &100i128);
     }
 }


### PR DESCRIPTION
- Add caller.require_auth() + owner/admin check to request_withdrawal()
- Add caller.require_auth() + admin-only check to approve_withdrawal()
- Validate campaign exists and is active via cross-contract get_campaign() before recording a donation
- Update MockCampaignContract with get_campaign(), set_campaign_owner(), set_campaign_status() to support the new cross-contract calls in tests
- Add auth-failure tests: unauthorized request_withdrawal, unauthorized approve_withdrawal, donation to inactive campaign, donation to nonexistent campaign

Closes #34 